### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To get a local copy up and running follow these simple example steps.
 1. Clone the repo
 
 ```sh
- git clone https://github.com/JoaoFranco03/photography-portfolio/.git
+ git clone https://github.com/JoaoFranco03/photography-portfolio.git
 ```
 
 2.  Run the following command:


### PR DESCRIPTION
Removes slash before .git in clone link, preventing terminals from recognizing repository.